### PR TITLE
fix style in safari

### DIFF
--- a/src/styles/base.css.js
+++ b/src/styles/base.css.js
@@ -21,4 +21,9 @@ export default global`
     padding-top: 100px;
     margin-top: -100px;
   }
+
+  * {
+    margin: 0;
+    padding: 0;
+  }
 `

--- a/src/styles/footer.css.js
+++ b/src/styles/footer.css.js
@@ -34,7 +34,7 @@ export default css`
         .tel {
           font-size: 30px;
           margin-top: 10px;
-          a {
+          :global(a) {
             color: #ffffff;
             text-decoration: none;
           }


### PR DESCRIPTION
- [x] Safariでのみbuttonタグにデフォルトでmarginが追加されており建築事例のグリッドが崩れていたので修正
- [x] 電話番号がaタグで青字になっていたのを白に修正